### PR TITLE
enable multi-gpu training ( torch.nn.DataParallel)

### DIFF
--- a/u2net_train.py
+++ b/u2net_train.py
@@ -101,7 +101,11 @@ elif(model_name=='u2netp'):
     net = U2NETP(3,1)
 
 if torch.cuda.is_available():
-    net.cuda()
+    n_gpu = torch.cuda.device_count()
+    if n_gpu > 1:
+        print(f"Found {n_gpu} GPUs. Using DataParallel.")
+        net = nn.DataParallel(net)       # wrap for multi-GPU
+    net = net.cuda()                    # send to CUDA (all replicas)
 
 # ------- 4. define optimizer --------
 print("---define optimizer...")

--- a/u2net_train.py
+++ b/u2net_train.py
@@ -103,7 +103,7 @@ elif(model_name=='u2netp'):
 if torch.cuda.is_available():
     n_gpu = torch.cuda.device_count()
     if n_gpu > 1:
-        print(f"Found {n_gpu} GPUs. Using DataParallel.")
+        print(f"Found {n_gpu} GPUs. Using torch.nn.DataParallel.")
         net = nn.DataParallel(net)       # wrap for multi-GPU
     net = net.cuda()                    # send to CUDA (all replicas)
 


### PR DESCRIPTION
On a dual-RTX3090 setup, this
increased speed from roughly 3.6 to 4.1 iters/s,
a modest 14% speed increase..
GPU0 runs at ~93% and GPU1 runs at ~10%,

Not sure why GPU1 is so under-utilized,
but it does get faster.